### PR TITLE
Revert #282 zenodo doi update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation Status](https://readthedocs.org/projects/biospecdb/badge/?version=latest)](https://biospecdb.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/RISPaDD/biospecdb/graph/badge.svg?token=Ld95EDCYNZ)](https://codecov.io/gh/RISPaDD/biospecdb)
 [![Security](https://github.com/rispadd/biospecdb/actions/workflows/security.yml/badge.svg)](https://github.com/rispadd/biospecdb/actions/workflows/security.yml)
-[![DOI](https://zenodo.org/badge/639473357.svg)](https://zenodo.org/doi/10.5281/zenodo.10048399)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10048241.svg)](https://doi.org/10.5281/zenodo.10048241)
 
 ![SSEC-JHU Logo](docs/_static/SSEC_logo_horiz_blue_1152x263.png)
 


### PR DESCRIPTION
https://doi.org/10.5281/zenodo.10048241 will always point to the latest build/release, which is what we want.