### PR TITLE
295 Fix center deletion

### DIFF
--- a/biospecdb/apps/uploader/admin.py
+++ b/biospecdb/apps/uploader/admin.py
@@ -14,6 +14,7 @@ from biospecdb.util import to_bool
 from .models import BioSample, Observable, Instrument, Patient, SpectralData, Observation, UploadedFile, Visit,\
     QCAnnotator, QCAnnotation, Center, get_center, BioSampleType, SpectraMeasurementType
 from uploader.forms import ModelForm
+from user.admin import CenterAdmin as UserCenterAdmin
 
 User = get_user_model()
 
@@ -759,29 +760,9 @@ class PatientAdminWithInlines(PatientAdmin):
     inlines = [VisitInline]
 
 
-# NOTE: The following admin can be used to visually sanity check that changes by user.models.Center to the "default" DB
-# get reflected in the "bsr" DB. We never want uploader.models.Center to be editable by any admin page, so we restrict
-# access below even if this is never used. Admin functionality belong to the admin page for ``user.models.Center``.
-# @admin.register(Center)
-# class CenterAdmin(admin.ModelAdmin):
-#     fields = ("name", "country", "id")
-#     list_display = ("name", "country")
-#     readonly_fields = ("name", "country", "id")
-#
-#     def has_view_permission(self, request, obj=None):
-#         return request.user.is_superuser
-#
-#     def has_module_permission(self, request):
-#         return request.user.is_superuser
-#
-#     def has_add_permission(self, request):
-#         return False
-#
-#     def has_change_permission(self, request, obj=None):
-#         return False
-#
-#     def has_delete_permission(self, request, obj=None):
-#         return False
+@admin.register(Center)
+class CenterAdmin(UserCenterAdmin):
+    ...
 
 
 class DataAdminSite(admin.AdminSite):

--- a/biospecdb/apps/uploader/models.py
+++ b/biospecdb/apps/uploader/models.py
@@ -9,6 +9,8 @@ from django.core.files.base import ContentFile
 from django.core.validators import FileExtensionValidator, MinValueValidator
 from django.db import models
 from django.db.models.functions import Lower
+from django.db.models.signals import post_delete
+from django.dispatch import receiver
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 import pandas as pd
@@ -63,7 +65,19 @@ NEGATIVE = "negative"
 
 
 class Center(UserBaseCenter):
-    ...
+    @property
+    def replica_model(self):
+        from user.models import Center as UserCenter
+        return UserCenter
+
+    @property
+    def replica_db(self):
+        return "default"
+
+
+@receiver(post_delete, sender=Center)
+def center_deletion_handler(sender, **kwargs):
+    kwargs["instance"].delete_replica()
 
 
 class UploadedFile(DatedModel):

--- a/biospecdb/apps/user/tests/test_center.py
+++ b/biospecdb/apps/user/tests/test_center.py
@@ -58,13 +58,14 @@ class TestCenters:
         assert not UserCenter.objects.all()
         assert not UploaderCenter.objects.all()
 
-    def test_bulk_delete_replication(self, centers):
+    @pytest.mark.parametrize("center", (UserCenter, UploaderCenter))
+    def test_bulk_delete_replication(self, center, centers):
         """ Bulk delete doesn't call delete() so this is handled by a post_delete signale handler. """
 
         assert UserCenter.objects.count() == 3
         assert UploaderCenter.objects.count() == 3
 
-        UserCenter.objects.all().delete()
+        center.objects.all().delete()
 
         assert not UserCenter.objects.all()
         assert UploaderCenter.objects.count() == 0

--- a/biospecdb/apps/user/tests/test_center.py
+++ b/biospecdb/apps/user/tests/test_center.py
@@ -59,7 +59,7 @@ class TestCenters:
         assert not UploaderCenter.objects.all()
 
     def test_bulk_delete_replication(self, centers):
-        """ Bulk delete doesn't call delete()!!! """
+        """ Bulk delete doesn't call delete() so this is handled by a post_delete signale handler. """
 
         assert UserCenter.objects.count() == 3
         assert UploaderCenter.objects.count() == 3
@@ -67,7 +67,7 @@ class TestCenters:
         UserCenter.objects.all().delete()
 
         assert not UserCenter.objects.all()
-        assert UploaderCenter.objects.count() == 3
+        assert UploaderCenter.objects.count() == 0
 
     def test_equivalence(self):
         user_center = UserCenter(name="test", country="nowhere")


### PR DESCRIPTION
Resolves #295

So this isn't complete, whilst this will now delete all centers upon request, related/protected items will not necessarily be correctly displayed in the to_delete list. They will, however, be correctly protected, so this PR is safe in that regard. 

Back story: ``Center`` is a duplicated table/model existing on both ``admin`` (default) and ``bsr`` databases (we needed the DB split for the separation of user data from actual data). Relations can't exist across DBs even for PostgreSQL.

One stop-gap measure is to swap the admins, i.e., ``user.models.Center`` is related to only the ``user.models.User``, whilst ``uploader.models.Center`` is related to pretty much all of the data objects via one relation or another. It would be better to display all the data that would need to be deleted compared to just a few users.
The next stop-gap measure would be to add both admins.

For this PR, I'll go with 2nd stop-gap and display both admins for ``Center`` - these are only visible to admin users anyhow.

The correct fix is to automatically do both and list all relations across both DBs. Punted to #303 as I'll get around to this shortly but it would still be better to merge in the above.