### PR TITLE
Group dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all-minor-and-patch-dependency-updates:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
See [group docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)

This PR groups all minor and patch dependency updates into a single PR. All other dependencies will be opened as separate PRs, e.g.,:

security updates:
>Note: If a grouped pull request for Dependabot version updates contains a vulnerable package, Dependabot security updates will still attempt to create a separate pull request to update the vulnerable package to a secure version. Creating a separate pull request for security updates ensures you have visibility into package vulnerabilities.

major updates:
>If a dependency doesn't belong to any group, Dependabot will continue to raise single pull requests to update the dependency to its latest version as normal.