### PR TITLE
AWS apprunner: install deps from docs.txt not dev.txt

### DIFF
--- a/apprunner.yaml
+++ b/apprunner.yaml
@@ -6,7 +6,7 @@ build:
       - pip3 install pipenv
       - pipenv install -r requirements/prd.txt
     post-build:
-      - pipenv install -r requirements/dev.txt
+      - pipenv install -r requirements/docs.txt
       - cd docs/
       - make html
       - cd ../


### PR DESCRIPTION
Fix copy and paste error from #337 .