### PR TITLE
S3 storage: don't clobber and make more secure

### DIFF
--- a/biospecdb/settings/aws.py
+++ b/biospecdb/settings/aws.py
@@ -10,7 +10,11 @@ STORAGES = {
             "bucket_name": os.getenv("AWS_STORAGE_BUCKET_NAME"),
             "region_name": os.getenv("AWS_S3_REGION_NAME"),
             "use_ssl": True,
-            "url_protocol": "https"
+            "url_protocol": "https",
+            "file_overwrite": False,  # Set this to False to have extra characters appended.
+            "default_acl": "private",  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl
+            "querystring_auth": True,  # Query parameter authentication from generated URLs.
+            "querystring_expire": 60  # The number of seconds that a generated URL is valid for.
         },
     },
     "staticfiles": {


### PR DESCRIPTION
Production deployment uses AWS S3 and [django-storages](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html) to generate temporary access URLs to downloadable data.

Changes:

 - With the default configuration, a generated URL would expire in 3600 seconds (1 hour). This PR reduces this to 1 minute.
 - Default configuration was to cobber files: this PR fixes that and instead a random str will be appended to the file mimicking standard Django behaviour.

In relation to #349, the generated URLs are that for S3, e.g., ``https://biospecdb-media-files.s3.amazonaws.com/``, and not ``/media/`` as specified in ``biospecdb.urls`` which means login is NOT required to access the downloads - they are available post-logout, but are temporary. Login is required to obtain the generated URL in the first place though.

Punt:

- Setting ``CacheControl``. We may want to disable this entirely. 