### PR TITLE
Temporarily limit matplotlib <3.9.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,3 +4,5 @@ sphinx==6.2.1
 sphinx_rtd_theme==2.0.0
 sphinx-automodapi==0.17.0
 nbsphinx==0.9.3
+
+matplotlib<3.9.0  # See https://github.com/DeepLabCut/DeepLabCut/issues/2581

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -15,3 +15,5 @@ psycopg[binary,pool]==3.1.18
 pyyaml==6.0.1
 xlsxwriter==3.2.0
 whitenoise==6.6.0
+
+matplotlib<3.9.0  # See https://github.com/DeepLabCut/DeepLabCut/issues/2581


### PR DESCRIPTION
We don't directly spec this, however, it's used by plotly.

See DeepLabCut/DeepLabCut#2581 in relation to attribute error.