### PR TITLE
ruff <path> is deprecated, use ruff check <path> instead

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -5,7 +5,7 @@
 
 
 echo Running ruff linter tests...
-TEST_RESULTS=$(ruff .)
+TEST_RESULTS=$(tox -e check-style)
 RETURN_VALUE=$?
 if [ $RETURN_VALUE != 0 ]; then
   echo "$TEST_RESULTS"

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ skip_install = true
 deps =
     -r requirements/test.txt
 commands =
-    ruff . {posargs}
+    ruff check . {posargs}
 
 [testenv:check-security]
 description = run bandit to check security compliance


### PR DESCRIPTION
This should fix failing CI linting in #362 